### PR TITLE
support: Innodb_redo_log_enabled

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,13 +13,14 @@ type Config struct {
 }
 
 type Database struct {
-	Type     DatabaseType `yaml:"type"`
-	Name     string       `yaml:"name"`
-	Image    string       `yaml:"image"`
-	User     string       `yaml:"user"`
-	Password string       `yaml:"password"`
-	Host     string       `yaml:"host"`
-	Port     string       `yaml:"port"`
+	Type           DatabaseType `yaml:"type"`
+	Name           string       `yaml:"name"`
+	Image          string       `yaml:"image"`
+	User           string       `yaml:"user"`
+	Password       string       `yaml:"password"`
+	Host           string       `yaml:"host"`
+	Port           string       `yaml:"port"`
+	DisableRedoLog bool         `yaml:"disable_redo_log"`
 }
 
 type DatabaseCheckTarget struct {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -99,21 +99,26 @@ func (d Database) Initialize() error {
 			return err
 		}
 	}
-	if d.cfg.Database.DisableRedoLog {
-		version, err := d.fetchVersion()
-		if err != nil {
-			return err
-		}
 
-		if version[0] >= 8 && version[2] >= 21 {
-			_, err := d.db.Exec("ALTER INSTANCE DISABLE INNODB REDO_LOG;")
+	switch d.cfg.Database.Type {
+	case "mysql":
+		if d.cfg.Database.DisableRedoLog {
+			version, err := d.fetchVersion()
 			if err != nil {
 				return err
 			}
-		} else {
-			return fmt.Errorf("Innodb_redo_log_enabled only supports versions newer than 8.0.20")
+
+			if version[0] >= 8 && version[2] >= 21 {
+				_, err := d.db.Exec("ALTER INSTANCE DISABLE INNODB REDO_LOG;")
+				if err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("Innodb_redo_log_enabled only supports versions newer than 8.0.20")
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/sample/config.yaml
+++ b/sample/config.yaml
@@ -5,6 +5,7 @@ database:
   password: root
   host: 127.0.0.1
   port: 33060
+  disable_redo_log: false
 check:
 - query: "select * from test"
   operator: exists


### PR DESCRIPTION
Thanks for the very useful tool! ! ! I came up with an idea that seems to be a little faster, so I'll propose it!

---

Add option to configure redo log disable released in MySQL 8.0.21. Enabling this option can speed things up by 20% to 30%.

ref: https://dev.mysql.com/doc/refman/8.0/en/innodb-redo-log.html#innodb-disable-redo-logging

#### benchmark

Here are the results of the benchmark in the local environment

```
# test file size
3.3G	test.dump

# redo log: Enable
real	14m3.015s

# redo log: Disable
real	11m17.501s

```

